### PR TITLE
RF-42: Active event replaces cart (phases 1-3)

### DIFF
--- a/Backend/cmd/main/api.go
+++ b/Backend/cmd/main/api.go
@@ -148,6 +148,10 @@ func (app *Application) Mount() http.Handler {
 			r.Use(app.AuthTokenMiddleware())
 			r.Post("/", app.createEventHandler)
 			r.Get("/", app.getUserEventsHandler)
+			// /events/active returns the user's draft event, creating it
+			// on demand. This is the entry point for the catalog "+" flow.
+			r.Get("/active", app.getActiveEventHandler)
+			r.Patch("/active/items/{itemId}", app.updateActiveEventItemHandler)
 			r.Get("/{id}", app.getEventHandler)
 			r.Put("/{id}", app.updateEventHandler)
 			r.Post("/{id}/pay", app.payEventHandler)

--- a/Backend/cmd/main/calendar.go
+++ b/Backend/cmd/main/calendar.go
@@ -42,6 +42,14 @@ func (app *Application) getEventCalendarHandler(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// A draft event without a date can't be exported as an ICS — there's
+	// nothing to put in DTSTART. Reject early so the caller can prompt the
+	// user to pick a date first.
+	if event.Date == nil {
+		app.badRequest(w, r, errors.New("event has no date set yet"))
+		return
+	}
+
 	// Create new calendar
 	cal := ics.NewCalendar()
 	cal.SetMethod(ics.MethodPublish)
@@ -61,7 +69,7 @@ func (app *Application) getEventCalendarHandler(w http.ResponseWriter, r *http.R
 	} else {
 		e.SetModifiedAt(time.Now())
 	}
-	e.SetStartAt(event.Date)
+	e.SetStartAt(*event.Date)
 	// As we don't have an explicit end time for events in this schema, let's assume a 4-hour duration
 	e.SetEndAt(event.Date.Add(4 * time.Hour))
 	e.SetSummary(event.Name)
@@ -87,7 +95,7 @@ func (app *Application) getEventCalendarHandler(w http.ResponseWriter, r *http.R
 				}
 			} else {
 				// Fallback to event date if no start time
-				te.SetStartAt(event.Date)
+				te.SetStartAt(*event.Date)
 				te.SetEndAt(event.Date.Add(30 * time.Minute))
 			}
 			te.SetSummary(fmt.Sprintf("%s - %s", event.Name, tl.Title))

--- a/Backend/cmd/main/events.go
+++ b/Backend/cmd/main/events.go
@@ -57,11 +57,11 @@ func (app *Application) createEventHandler(w http.ResponseWriter, r *http.Reques
 	event := &models.Event{
 		UserID:     user.ID,
 		Name:       payload.Name,
-		Date:       date,
+		Date:       &date,
 		Location:   payload.Location,
 		GuestCount: payload.GuestCount,
 		Budget:     payload.Budget,
-		Status:     "planning",
+		Status:     models.EventStatusPlanning,
 	}
 
 	if err := app.Store.Events.Create(r.Context(), event); err != nil {
@@ -210,7 +210,7 @@ func (app *Application) updateEventHandler(w http.ResponseWriter, r *http.Reques
 				}
 			}
 		}
-		event.Date = date
+		event.Date = &date
 	}
 	if payload.Location != nil {
 		event.Location = *payload.Location
@@ -303,8 +303,10 @@ func (app *Application) addEventItemHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	var payload struct {
-		ArticleID uuid.UUID `json:"article_id"`
-		Quantity  int       `json:"quantity"`
+		ArticleID     uuid.UUID  `json:"article_id"`
+		VariantID     *uuid.UUID `json:"variant_id"`
+		Quantity      int        `json:"quantity"`
+		PriceSnapshot *float64   `json:"price_snapshot"`
 	}
 	if err := readJson(w, r, &payload); err != nil {
 		app.badRequest(w, r, err)
@@ -328,28 +330,35 @@ func (app *Application) addEventItemHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	item := &models.EventItem{
-		EventID:   eventID,
-		ArticleID: payload.ArticleID,
-		Quantity:  payload.Quantity,
+		EventID:       eventID,
+		ArticleID:     payload.ArticleID,
+		VariantID:     payload.VariantID,
+		Quantity:      payload.Quantity,
+		PriceSnapshot: payload.PriceSnapshot,
 	}
 	if item.Quantity <= 0 {
 		item.Quantity = 1
 	}
 
-	// Phase 17: Availability & Inventory Check
-	availability, err := app.Store.Articles.GetAvailability(r.Context(), payload.ArticleID, event.Date)
-	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			app.notFoundResponse(w, r, err)
-		} else {
-			app.internalServerError(w, r, err)
+	// Availability check — only enforced when the event has a date.
+	// Drafts (the user's "active event" while browsing the catalog) skip
+	// this check; availability gets validated again when the user picks
+	// a date and the event transitions out of draft.
+	if event.Date != nil {
+		availability, err := app.Store.Articles.GetAvailability(r.Context(), payload.ArticleID, *event.Date)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				app.notFoundResponse(w, r, err)
+			} else {
+				app.internalServerError(w, r, err)
+			}
+			return
 		}
-		return
-	}
 
-	if availability < item.Quantity {
-		app.badRequest(w, r, errors.New("insufficient stock for this date"))
-		return
+		if availability < item.Quantity {
+			app.badRequest(w, r, errors.New("insufficient stock for this date"))
+			return
+		}
 	}
 
 	if err := app.Store.Events.AddItem(r.Context(), item); err != nil {
@@ -635,4 +644,106 @@ func (app *Application) getEventDebriefHandler(w http.ResponseWriter, r *http.Re
 	if err := app.jsonResponse(w, http.StatusOK, debrief); err != nil {
 		app.internalServerError(w, r, err)
 	}
+}
+
+// getActiveEventHandler godoc
+//
+//	@Summary		Get the user's active (draft) event
+//	@Description	Returns the user's current draft event with its items.
+//	                Creates an empty draft on demand if none exists, so the
+//	                caller never has to handle a "no active event" case.
+//	@Tags			events
+//	@Produce		json
+//	@Security		BearerAuth
+//	@Success		200	{object}	map[string]interface{}
+//	@Failure		500	{object}	error
+//	@Router			/events/active [get]
+func (app *Application) getActiveEventHandler(w http.ResponseWriter, r *http.Request) {
+	user := GetUserFromCtx(r)
+
+	event, err := app.Store.Events.GetOrCreateDraft(r.Context(), user.ID)
+	if err != nil {
+		app.internalServerError(w, r, err)
+		return
+	}
+
+	items, err := app.Store.Events.GetItems(r.Context(), event.ID)
+	if err != nil {
+		app.internalServerError(w, r, err)
+		return
+	}
+
+	resp := map[string]interface{}{
+		"event": event,
+		"items": items,
+	}
+	if err := app.jsonResponse(w, http.StatusOK, resp); err != nil {
+		app.internalServerError(w, r, err)
+	}
+}
+
+// updateActiveEventItemHandler godoc
+//
+//	@Summary		Update quantity of an item in the active draft event
+//	@Description	Sets the absolute quantity of a single line in the user's
+//	                draft event. Quantity 0 deletes the line.
+//	@Tags			events
+//	@Accept			json
+//	@Produce		json
+//	@Param			itemId	path	string	true	"Event item ID"
+//	@Param			payload	body	object	true	"Quantity payload"
+//	@Security		BearerAuth
+//	@Success		200	{object}	models.EventItem
+//	@Failure		400	{object}	error
+//	@Failure		404	{object}	error
+//	@Failure		500	{object}	error
+//	@Router			/events/active/items/{itemId} [patch]
+func (app *Application) updateActiveEventItemHandler(w http.ResponseWriter, r *http.Request) {
+	user := GetUserFromCtx(r)
+
+	itemID, err := uuid.Parse(chi.URLParam(r, "itemId"))
+	if err != nil {
+		app.badRequest(w, r, err)
+		return
+	}
+
+	var payload struct {
+		Quantity int `json:"quantity"`
+	}
+	if err := readJson(w, r, &payload); err != nil {
+		app.badRequest(w, r, err)
+		return
+	}
+
+	// Resolve the user's draft so we can authorize the operation against it.
+	event, err := app.Store.Events.GetOrCreateDraft(r.Context(), user.ID)
+	if err != nil {
+		app.internalServerError(w, r, err)
+		return
+	}
+
+	// Quantity 0 (or negative) means "remove this line".
+	if payload.Quantity <= 0 {
+		if err := app.Store.Events.RemoveItem(r.Context(), event.ID, itemID); err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				app.notFoundResponse(w, r, err)
+			} else {
+				app.internalServerError(w, r, err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if err := app.Store.Events.UpdateItemQuantity(r.Context(), itemID, payload.Quantity); err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			app.notFoundResponse(w, r, err)
+		} else {
+			app.internalServerError(w, r, err)
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/Backend/cmd/migrate/migrations/000043_events_support_drafts.down.sql
+++ b/Backend/cmd/migrate/migrations/000043_events_support_drafts.down.sql
@@ -1,0 +1,14 @@
+-- Reverse 000043_events_support_drafts.up.sql
+
+DROP INDEX IF EXISTS event_items_event_article_variant_unique;
+ALTER TABLE event_items DROP COLUMN IF EXISTS price_snapshot;
+ALTER TABLE event_items DROP COLUMN IF EXISTS variant_id;
+-- Restore the old uniqueness constraint
+ALTER TABLE event_items
+    ADD CONSTRAINT event_items_event_id_article_id_key UNIQUE (event_id, article_id);
+
+DROP INDEX IF EXISTS events_user_active_draft;
+ALTER TABLE events DROP CONSTRAINT IF EXISTS events_status_check;
+ALTER TABLE events ALTER COLUMN status SET DEFAULT 'planning';
+ALTER TABLE events ALTER COLUMN name SET NOT NULL;
+ALTER TABLE events ALTER COLUMN date SET NOT NULL;

--- a/Backend/cmd/migrate/migrations/000043_events_support_drafts.up.sql
+++ b/Backend/cmd/migrate/migrations/000043_events_support_drafts.up.sql
@@ -1,0 +1,49 @@
+-- Make events able to behave as drafts (nameless, dateless) so they can act
+-- as the user's "active event" while they browse the catalog.
+
+-- 1. Allow date to be NULL — drafts may not have a chosen date yet.
+ALTER TABLE events ALTER COLUMN date DROP NOT NULL;
+
+-- 2. Allow name to be empty/default — drafts don't need a name until they
+--    are confirmed. Existing rows that are non-empty stay untouched.
+ALTER TABLE events ALTER COLUMN name DROP NOT NULL;
+
+-- 3. Default new events to 'draft' (was 'planning'). Existing rows keep
+--    whatever status they already had.
+ALTER TABLE events ALTER COLUMN status SET DEFAULT 'draft';
+
+-- 4. Add a CHECK so the status column is always one of the known values.
+--    'planning' is preserved as a legacy value to avoid breaking old rows.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'events_status_check'
+    ) THEN
+        ALTER TABLE events
+            ADD CONSTRAINT events_status_check
+            CHECK (status IN (
+                'draft', 'planning', 'requested', 'adjusted',
+                'confirmed', 'paid', 'completed', 'cancelled'
+            ));
+    END IF;
+END $$;
+
+-- 5. Index to quickly find a user's single draft event.
+CREATE UNIQUE INDEX IF NOT EXISTS events_user_active_draft
+    ON events (user_id)
+    WHERE status = 'draft';
+
+-- 6. event_items: add variant_id and price_snapshot to match what cart_items
+--    used to capture, so the catalog "+" button can record exactly which
+--    variant the user picked and the price at the moment of adding.
+ALTER TABLE event_items
+    ADD COLUMN IF NOT EXISTS variant_id UUID REFERENCES article_variants(id) ON DELETE SET NULL;
+ALTER TABLE event_items
+    ADD COLUMN IF NOT EXISTS price_snapshot DECIMAL(12, 2);
+
+-- 7. The old (event_id, article_id) UNIQUE prevented adding two variants of
+--    the same article. Drop it and replace with a per-variant uniqueness so
+--    "Tiffany Rosa" and "Tiffany Negra" can coexist as separate line items.
+ALTER TABLE event_items DROP CONSTRAINT IF EXISTS event_items_event_id_article_id_key;
+CREATE UNIQUE INDEX IF NOT EXISTS event_items_event_article_variant_unique
+    ON event_items (event_id, article_id, COALESCE(variant_id, '00000000-0000-0000-0000-000000000000'::uuid));

--- a/Backend/frontend/lib/core/services/pdf_export_service.dart
+++ b/Backend/frontend/lib/core/services/pdf_export_service.dart
@@ -67,7 +67,7 @@ class PdfExportService {
                       pw.Text('DETALLES DEL EVENTO', style: pw.TextStyle(fontWeight: pw.FontWeight.bold, fontSize: 12, color: PdfColors.pink)),
                       pw.Divider(color: PdfColors.pink, thickness: 0.5),
                       pw.Text(event.name, style: pw.TextStyle(fontSize: 16, fontWeight: pw.FontWeight.bold)),
-                      pw.Text('Fecha: ${dateFormat.format(event.date)}'),
+                      pw.Text('Fecha: ${event.date != null ? dateFormat.format(event.date!) : "Sin definir"}'),
                       pw.Text('Ubicación: ${event.location}'),
                       pw.Text('Invitados: ${event.guestCount}'),
                     ]

--- a/Backend/frontend/lib/features/active_event/data/active_event_api_service.dart
+++ b/Backend/frontend/lib/features/active_event/data/active_event_api_service.dart
@@ -1,0 +1,54 @@
+import '../../../core/api_client.dart';
+import '../../events/data/event_model.dart';
+import 'active_event_response.dart';
+
+/// Talks to the backend `/events/active` endpoints. The draft event is
+/// the user's "working basket" — the catalog quick-add writes here.
+class ActiveEventApiService {
+  /// Fetches the current draft event, creating one on demand if none exists.
+  /// Returns both the event and its items so the caller doesn't have to
+  /// issue two requests.
+  Future<ActiveEventResponse> getActive() async {
+    final data = await ApiClient.get('/events/active');
+    return ActiveEventResponse.fromJson(data as Map<String, dynamic>);
+  }
+
+  /// Adds an item to the draft event. Backend upserts: calling this twice
+  /// with the same (article, variant) increments the existing line.
+  /// Returns the freshly-inserted/updated line.
+  Future<EventItem> addItem({
+    required String eventId,
+    required String articleId,
+    String? variantId,
+    required int quantity,
+    double? priceSnapshot,
+  }) async {
+    final data = await ApiClient.post('/events/$eventId/items', {
+      'article_id': articleId,
+      if (variantId != null) 'variant_id': variantId,
+      'quantity': quantity,
+      if (priceSnapshot != null) 'price_snapshot': priceSnapshot,
+    });
+    return EventItem.fromJson(data as Map<String, dynamic>);
+  }
+
+  /// Sets the absolute quantity for an item in the active draft.
+  /// Passing 0 (or anything <= 0) deletes the line on the backend.
+  Future<void> updateItemQuantity({
+    required String itemId,
+    required int quantity,
+  }) async {
+    await ApiClient.patch('/events/active/items/$itemId', {
+      'quantity': quantity,
+    });
+  }
+
+  /// Removes an item from the draft. This is a 204-returning endpoint
+  /// that the store layer exposes via the generic event `/items` route.
+  Future<void> removeItem({
+    required String eventId,
+    required String itemId,
+  }) async {
+    await ApiClient.delete('/events/$eventId/items/$itemId');
+  }
+}

--- a/Backend/frontend/lib/features/active_event/data/active_event_repository.dart
+++ b/Backend/frontend/lib/features/active_event/data/active_event_repository.dart
@@ -1,0 +1,39 @@
+import '../../events/data/event_model.dart';
+import 'active_event_api_service.dart';
+import 'active_event_response.dart';
+
+class ActiveEventRepository {
+  final ActiveEventApiService _apiService;
+
+  ActiveEventRepository({ActiveEventApiService? apiService})
+      : _apiService = apiService ?? ActiveEventApiService();
+
+  Future<ActiveEventResponse> getActive() => _apiService.getActive();
+
+  Future<EventItem> addItem({
+    required String eventId,
+    required String articleId,
+    String? variantId,
+    required int quantity,
+    double? priceSnapshot,
+  }) =>
+      _apiService.addItem(
+        eventId: eventId,
+        articleId: articleId,
+        variantId: variantId,
+        quantity: quantity,
+        priceSnapshot: priceSnapshot,
+      );
+
+  Future<void> updateItemQuantity({
+    required String itemId,
+    required int quantity,
+  }) =>
+      _apiService.updateItemQuantity(itemId: itemId, quantity: quantity);
+
+  Future<void> removeItem({
+    required String eventId,
+    required String itemId,
+  }) =>
+      _apiService.removeItem(eventId: eventId, itemId: itemId);
+}

--- a/Backend/frontend/lib/features/active_event/data/active_event_response.dart
+++ b/Backend/frontend/lib/features/active_event/data/active_event_response.dart
@@ -1,0 +1,21 @@
+import '../../events/data/event_model.dart';
+
+/// Response shape of `GET /v1/events/active`: the backend returns the draft
+/// event alongside its hydrated items in a single payload.
+class ActiveEventResponse {
+  final Event event;
+  final List<EventItem> items;
+
+  ActiveEventResponse({required this.event, required this.items});
+
+  factory ActiveEventResponse.fromJson(Map<String, dynamic> json) {
+    final eventJson = json['event'] as Map<String, dynamic>;
+    final itemsJson = (json['items'] as List<dynamic>?) ?? const [];
+    return ActiveEventResponse(
+      event: Event.fromJson(eventJson),
+      items: itemsJson
+          .map((e) => EventItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}

--- a/Backend/frontend/lib/features/active_event/presentation/active_event_provider.dart
+++ b/Backend/frontend/lib/features/active_event/presentation/active_event_provider.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/utils/error_translator.dart';
+import '../../events/data/event_model.dart';
+import '../../products/data/product_models.dart';
+import '../data/active_event_repository.dart';
+
+/// Holds the user's "active event" — a draft event that acts as their
+/// working basket while they browse the catalog. Replaces CartProvider.
+///
+/// The provider is intentionally lazy: it only hits the backend on the
+/// first read or after an explicit `addItem` / `updateQuantity` / `clear`
+/// call, so the home screen does not pay a roundtrip if the user never
+/// touches a product.
+class ActiveEventProvider extends ChangeNotifier {
+  final ActiveEventRepository _repository;
+
+  ActiveEventProvider({ActiveEventRepository? repository})
+      : _repository = repository ?? ActiveEventRepository();
+
+  Event? _event;
+  Event? get event => _event;
+
+  List<EventItem> _items = const [];
+  List<EventItem> get items => _items;
+
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
+
+  String? _error;
+  String? get error => _error;
+
+  /// Total number of *units* in the draft (sum of all line quantities).
+  /// Used by the top-bar badge in the catalog.
+  int get itemCount =>
+      _items.fold<int>(0, (sum, item) => sum + item.quantity);
+
+  /// Number of distinct lines (one per article × variant tuple). Used in
+  /// the active event screen as a secondary stat.
+  int get lineCount => _items.length;
+
+  /// Estimated subtotal (no taxes, no additional costs).
+  double get subtotal =>
+      _items.fold<double>(0, (sum, item) => sum + item.lineTotal);
+
+  /// Hydrates the provider from the backend. Safe to call multiple times.
+  Future<void> fetch({bool force = false}) async {
+    if (_isLoading) return;
+    if (_event != null && !force) return;
+
+    _setLoading(true);
+    _error = null;
+    try {
+      final response = await _repository.getActive();
+      _event = response.event;
+      _items = response.items;
+    } catch (e) {
+      _error = ErrorTranslator.translate(e.toString());
+    } finally {
+      _setLoading(false);
+    }
+  }
+
+  /// Add a product to the draft event. Ensures the draft exists first
+  /// (single roundtrip via `getActive`) and then upserts the line.
+  ///
+  /// The optimistic path is intentionally simple: we don't pre-add the
+  /// line locally because the backend returns the canonical row (with
+  /// the merged quantity if it already existed) — we just refresh.
+  Future<void> addItem(
+    Product product, {
+    ProductVariant? variant,
+    int quantity = 1,
+  }) async {
+    if (quantity <= 0) return;
+
+    // Make sure we have a draft to write into.
+    if (_event == null) {
+      await fetch();
+      if (_event == null) return; // fetch failed; error already set
+    }
+
+    final variantToUse = variant ??
+        (product.variants.isNotEmpty ? product.variants.first : null);
+    final price = variantToUse?.rentalPrice;
+
+    _error = null;
+    try {
+      await _repository.addItem(
+        eventId: _event!.id,
+        articleId: product.id,
+        variantId: variantToUse?.id,
+        quantity: quantity,
+        priceSnapshot: price,
+      );
+      // Re-pull so the local list reflects the canonical merged state
+      // (and joined article/variant fields the backend computed).
+      await _refreshItems();
+    } catch (e) {
+      _error = ErrorTranslator.translate(e.toString());
+      notifyListeners();
+    }
+  }
+
+  /// Sets the absolute quantity of a line. Quantity 0 removes it.
+  Future<void> updateQuantity(String itemId, int quantity) async {
+    if (_event == null) return;
+
+    // Optimistic local update so the UI reacts instantly.
+    final previous = _items;
+    if (quantity <= 0) {
+      _items = _items.where((i) => i.id != itemId).toList();
+    } else {
+      _items = _items
+          .map((i) => i.id == itemId ? _withQuantity(i, quantity) : i)
+          .toList();
+    }
+    notifyListeners();
+
+    try {
+      await _repository.updateItemQuantity(
+        itemId: itemId,
+        quantity: quantity,
+      );
+    } catch (e) {
+      // Roll back on failure.
+      _items = previous;
+      _error = ErrorTranslator.translate(e.toString());
+      notifyListeners();
+    }
+  }
+
+  /// Removes a line from the draft. Convenience wrapper around
+  /// `updateQuantity(0)` so callers can be more explicit at the call site.
+  Future<void> removeItem(String itemId) => updateQuantity(itemId, 0);
+
+  /// Clears the local state — used after logout. Does not touch the
+  /// backend (the draft survives across sessions on purpose).
+  void clearLocal() {
+    _event = null;
+    _items = const [];
+    _error = null;
+    notifyListeners();
+  }
+
+  // ─── internals ─────────────────────────────────────────────────────────
+
+  Future<void> _refreshItems() async {
+    try {
+      final response = await _repository.getActive();
+      _event = response.event;
+      _items = response.items;
+      notifyListeners();
+    } catch (e) {
+      _error = ErrorTranslator.translate(e.toString());
+      notifyListeners();
+    }
+  }
+
+  EventItem _withQuantity(EventItem item, int quantity) {
+    return EventItem(
+      id: item.id,
+      eventId: item.eventId,
+      articleId: item.articleId,
+      variantId: item.variantId,
+      quantity: quantity,
+      priceSnapshot: item.priceSnapshot,
+      createdAt: item.createdAt,
+      article: item.article,
+      variant: item.variant,
+      price: item.price,
+    );
+  }
+
+  void _setLoading(bool value) {
+    _isLoading = value;
+    notifyListeners();
+  }
+}

--- a/Backend/frontend/lib/features/active_event/presentation/screens/mi_evento_screen.dart
+++ b/Backend/frontend/lib/features/active_event/presentation/screens/mi_evento_screen.dart
@@ -1,0 +1,526 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'package:frontend/core/design_system.dart';
+import 'package:frontend/core/app_colors.dart';
+
+import '../../../events/data/event_model.dart';
+import '../active_event_provider.dart';
+
+/// "Mi Evento" — replaces the cart screen.
+///
+/// Renders the user's draft event as a list of items + a totals section
+/// at the bottom. The CTA at the bottom is "Solicitar cotización" (not
+/// "Pay") because RosaFiesta is rental-first and the user is building an
+/// event, not buying a product.
+class MiEventoScreen extends StatefulWidget {
+  const MiEventoScreen({super.key});
+
+  @override
+  State<MiEventoScreen> createState() => _MiEventoScreenState();
+}
+
+class _MiEventoScreenState extends State<MiEventoScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      // Always refresh on entry so the screen reflects the latest server state.
+      context.read<ActiveEventProvider>().fetch(force: true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = RfTheme.of(context);
+    final provider = context.watch<ActiveEventProvider>();
+
+    return Scaffold(
+      backgroundColor: t.base,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back_rounded, color: t.textPrimary),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: ShaderMask(
+          shaderCallback: (b) => AppColors.titleGradient.createShader(b),
+          child: Text(
+            'Mi evento',
+            style: GoogleFonts.outfit(
+              fontSize: 22,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+            ),
+          ),
+        ),
+      ),
+      body: _buildBody(provider, t),
+    );
+  }
+
+  Widget _buildBody(ActiveEventProvider provider, RfTheme t) {
+    if (provider.isLoading && provider.event == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (provider.error != null && provider.items.isEmpty) {
+      return _ErrorState(message: provider.error!, t: t);
+    }
+
+    if (provider.items.isEmpty) {
+      return _EmptyState(t: t);
+    }
+
+    return Column(
+      children: [
+        if (provider.event?.date == null)
+          _DateMissingBanner(t: t),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: () => provider.fetch(force: true),
+            child: ListView.separated(
+              padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+              itemCount: provider.items.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final item = provider.items[index];
+                return _LineTile(
+                  item: item,
+                  t: t,
+                  onIncrement: () => provider.updateQuantity(
+                    item.id,
+                    item.quantity + 1,
+                  ),
+                  onDecrement: () => provider.updateQuantity(
+                    item.id,
+                    item.quantity - 1,
+                  ),
+                  onRemove: () => provider.removeItem(item.id),
+                );
+              },
+            ),
+          ),
+        ),
+        _TotalsBar(provider: provider, t: t),
+      ],
+    );
+  }
+}
+
+// ── Empty / error / banner states ──────────────────────────────────────────
+
+class _EmptyState extends StatelessWidget {
+  final RfTheme t;
+  const _EmptyState({required this.t});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(32, 0, 32, 80),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 110,
+              height: 110,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [
+                    AppColors.violet.withOpacity(0.18),
+                    AppColors.hotPink.withOpacity(0.18),
+                  ],
+                ),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.celebration_rounded,
+                color: AppColors.hotPink,
+                size: 56,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Tu evento está vacío',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.outfit(
+                fontSize: 22,
+                fontWeight: FontWeight.w700,
+                color: t.textPrimary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Explora el catálogo y agrega los artículos que necesitas para tu celebración.',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 14,
+                color: t.textMuted,
+                height: 1.45,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  final String message;
+  final RfTheme t;
+  const _ErrorState({required this.message, required this.t});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline_rounded,
+                size: 48, color: AppColors.coral),
+            const SizedBox(height: 12),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(fontSize: 14, color: t.textMuted),
+            ),
+            const SizedBox(height: 16),
+            RfLuxeButton(
+              label: 'Reintentar',
+              onTap: () => context
+                  .read<ActiveEventProvider>()
+                  .fetch(force: true),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DateMissingBanner extends StatelessWidget {
+  final RfTheme t;
+  const _DateMissingBanner({required this.t});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      decoration: BoxDecoration(
+        color: AppColors.amber.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: AppColors.amber.withOpacity(0.3)),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.calendar_today_rounded,
+              color: AppColors.amber, size: 20),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'Aún no has elegido una fecha. La disponibilidad real se valida cuando confirmas tu evento.',
+              style: GoogleFonts.dmSans(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: t.textPrimary,
+                height: 1.35,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Line tile ──────────────────────────────────────────────────────────────
+
+class _LineTile extends StatelessWidget {
+  final EventItem item;
+  final RfTheme t;
+  final VoidCallback onIncrement;
+  final VoidCallback onDecrement;
+  final VoidCallback onRemove;
+
+  const _LineTile({
+    required this.item,
+    required this.t,
+    required this.onIncrement,
+    required this.onDecrement,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final imageUrl = item.variant?.imageUrl;
+    final articleName = item.article?.nameTemplate ?? 'Artículo';
+    final variantName = item.variant?.name;
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: t.isDark ? t.card : Colors.white,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: t.borderFaint),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(12),
+            child: SizedBox(
+              width: 72,
+              height: 72,
+              child: imageUrl != null && imageUrl.isNotEmpty
+                  ? Image.network(
+                      imageUrl,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => Container(
+                        color: AppColors.hotPink.withOpacity(0.08),
+                        child: const Icon(Icons.image_not_supported_rounded,
+                            color: AppColors.hotPink),
+                      ),
+                    )
+                  : Container(
+                      color: AppColors.hotPink.withOpacity(0.08),
+                      child: const Icon(Icons.image_not_supported_rounded,
+                          color: AppColors.hotPink),
+                    ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  articleName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: GoogleFonts.dmSans(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: t.textPrimary,
+                  ),
+                ),
+                if (variantName != null && variantName.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    variantName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 12,
+                      color: t.textMuted,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 8),
+                ShaderMask(
+                  shaderCallback: (b) => const LinearGradient(colors: [
+                    AppColors.violet,
+                    AppColors.hotPink,
+                  ]).createShader(b),
+                  child: Text(
+                    'RD\$ ${item.lineTotal.toStringAsFixed(0)}',
+                    style: GoogleFonts.outfit(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          _QuantityStepper(
+            quantity: item.quantity,
+            onIncrement: onIncrement,
+            onDecrement: onDecrement,
+            t: t,
+          ),
+          IconButton(
+            icon: Icon(Icons.close_rounded, color: t.textDim, size: 20),
+            onPressed: onRemove,
+            tooltip: 'Quitar',
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(
+              minWidth: 30,
+              minHeight: 30,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _QuantityStepper extends StatelessWidget {
+  final int quantity;
+  final VoidCallback onIncrement;
+  final VoidCallback onDecrement;
+  final RfTheme t;
+
+  const _QuantityStepper({
+    required this.quantity,
+    required this.onIncrement,
+    required this.onDecrement,
+    required this.t,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: t.isDark
+            ? Colors.white.withOpacity(0.04)
+            : Colors.black.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _StepBtn(
+            icon: Icons.remove_rounded,
+            onTap: onDecrement,
+            t: t,
+          ),
+          SizedBox(
+            width: 24,
+            child: Text(
+              '$quantity',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.dmSans(
+                fontSize: 14,
+                fontWeight: FontWeight.w700,
+                color: t.textPrimary,
+              ),
+            ),
+          ),
+          _StepBtn(
+            icon: Icons.add_rounded,
+            onTap: onIncrement,
+            t: t,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StepBtn extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  final RfTheme t;
+  const _StepBtn({required this.icon, required this.onTap, required this.t});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(20),
+      child: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Icon(icon, size: 16, color: t.textPrimary),
+      ),
+    );
+  }
+}
+
+// ── Totals bar ─────────────────────────────────────────────────────────────
+
+class _TotalsBar extends StatelessWidget {
+  final ActiveEventProvider provider;
+  final RfTheme t;
+  const _TotalsBar({required this.provider, required this.t});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+        20,
+        16,
+        20,
+        16 + MediaQuery.of(context).padding.bottom,
+      ),
+      decoration: BoxDecoration(
+        color: t.isDark ? t.card : Colors.white,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 16,
+            offset: const Offset(0, -4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Estimado',
+                style: GoogleFonts.dmSans(
+                  fontSize: 13,
+                  color: t.textMuted,
+                ),
+              ),
+              const Spacer(),
+              ShaderMask(
+                shaderCallback: (b) => const LinearGradient(colors: [
+                  AppColors.violet,
+                  AppColors.hotPink,
+                ]).createShader(b),
+                child: Text(
+                  'RD\$ ${provider.subtotal.toStringAsFixed(0)}',
+                  style: GoogleFonts.outfit(
+                    fontSize: 26,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            '${provider.itemCount} ${provider.itemCount == 1 ? "artículo" : "artículos"} · ${provider.lineCount} ${provider.lineCount == 1 ? "línea" : "líneas"}',
+            style: GoogleFonts.dmSans(
+              fontSize: 12,
+              color: t.textDim,
+            ),
+          ),
+          const SizedBox(height: 16),
+          RfLuxeButton(
+            label: 'Solicitar cotización',
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text(
+                      'Solicitar cotización: próximamente conectado al flujo de eventos'),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/Backend/frontend/lib/features/events/data/event_model.dart
+++ b/Backend/frontend/lib/features/events/data/event_model.dart
@@ -2,7 +2,9 @@ class Event {
   final String id;
   final String userId;
   final String name;
-  final DateTime date;
+  // Nullable because a draft event (the user's "active event" while they
+  // are browsing the catalog) may not have a date picked yet.
+  final DateTime? date;
   final String location;
   final int guestCount;
   final double budget;
@@ -17,7 +19,7 @@ class Event {
     required this.id,
     required this.userId,
     required this.name,
-    required this.date,
+    this.date,
     required this.location,
     required this.guestCount,
     required this.budget,
@@ -29,15 +31,19 @@ class Event {
     this.paidAt,
   });
 
+  /// True when this event is the user's draft "active event" — their
+  /// working basket before they commit to a date / name.
+  bool get isDraft => status == 'draft';
+
   factory Event.fromJson(Map<String, dynamic> json) {
     return Event(
       id: json['id'],
       userId: json['user_id'],
-      name: json['name'],
-      date: DateTime.parse(json['date']),
-      location: json['location'],
-      guestCount: json['guest_count'],
-      budget: (json['budget'] as num).toDouble(),
+      name: json['name'] ?? '',
+      date: json['date'] != null ? DateTime.parse(json['date']) : null,
+      location: json['location'] ?? '',
+      guestCount: json['guest_count'] ?? 0,
+      budget: (json['budget'] as num?)?.toDouble() ?? 0.0,
       additionalCosts: (json['additional_costs'] as num?)?.toDouble() ?? 0.0,
       adminNotes: json['admin_notes'],
       status: json['status'],
@@ -52,7 +58,7 @@ class Event {
       'id': id,
       'user_id': userId,
       'name': name,
-      'date': date.toIso8601String(),
+      'date': date?.toIso8601String(),
       'location': location,
       'guest_count': guestCount,
       'budget': budget,
@@ -98,33 +104,83 @@ class ArticleLite {
   }
 }
 
+/// Lightweight variant info that comes joined in event_items responses.
+class EventItemVariant {
+  final String id;
+  final String sku;
+  final String name;
+  final String? imageUrl;
+  final double rentalPrice;
+
+  EventItemVariant({
+    required this.id,
+    required this.sku,
+    required this.name,
+    this.imageUrl,
+    required this.rentalPrice,
+  });
+
+  factory EventItemVariant.fromJson(Map<String, dynamic> json) {
+    return EventItemVariant(
+      id: json['id'],
+      sku: json['sku'] ?? '',
+      name: json['name'] ?? '',
+      imageUrl: json['image_url'],
+      rentalPrice: (json['rental_price'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+}
+
 class EventItem {
   final String id;
   final String eventId;
   final String articleId;
+  final String? variantId;
   final int quantity;
+  final double? priceSnapshot;
   final DateTime createdAt;
   final ArticleLite? article;
+  final EventItemVariant? variant;
   final double? price;
 
   EventItem({
     required this.id,
     required this.eventId,
     required this.articleId,
+    this.variantId,
     required this.quantity,
+    this.priceSnapshot,
     required this.createdAt,
     this.article,
+    this.variant,
     this.price,
   });
+
+  /// Effective price per unit — falls back through snapshot → variant
+  /// rental → the joined `price` column computed by the backend.
+  double get unitPrice {
+    if (priceSnapshot != null) return priceSnapshot!;
+    if (variant != null) return variant!.rentalPrice;
+    if (price != null) return price!;
+    return 0.0;
+  }
+
+  double get lineTotal => unitPrice * quantity;
 
   factory EventItem.fromJson(Map<String, dynamic> json) {
     return EventItem(
       id: json['id'],
       eventId: json['event_id'],
       articleId: json['article_id'],
+      variantId: json['variant_id'],
       quantity: json['quantity'],
+      priceSnapshot: (json['price_snapshot'] as num?)?.toDouble(),
       createdAt: DateTime.parse(json['created_at']),
-      article: json['article'] != null ? ArticleLite.fromJson(json['article']) : null,
+      article:
+          json['article'] != null ? ArticleLite.fromJson(json['article']) : null,
+      variant: json['variant'] != null
+          ? EventItemVariant.fromJson(json['variant'])
+          : null,
       price: json['price'] != null ? (json['price'] as num).toDouble() : null,
     );
   }

--- a/Backend/frontend/lib/features/events/presentation/events_provider.dart
+++ b/Backend/frontend/lib/features/events/presentation/events_provider.dart
@@ -219,9 +219,12 @@ class EventsProvider extends ChangeNotifier {
 
   void _syncEventNotifications() {
     for (var event in _events) {
-      if (event.date.isAfter(DateTime.now())) {
+      // Drafts (and any event missing a date) can't generate reminders.
+      final date = event.date;
+      if (date == null) continue;
+      if (date.isAfter(DateTime.now())) {
         // Schedule reminder 24 hours before the event
-        final reminderDate = event.date.subtract(const Duration(hours: 24));
+        final reminderDate = date.subtract(const Duration(hours: 24));
         if (reminderDate.isAfter(DateTime.now())) {
           _notificationService.scheduleNotification(
             id: event.id.hashCode,

--- a/Backend/frontend/lib/features/events/presentation/screens/events_list_screen.dart
+++ b/Backend/frontend/lib/features/events/presentation/screens/events_list_screen.dart
@@ -61,7 +61,8 @@ class _EventsListScreenState extends State<EventsListScreen> {
                 margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                 child: ListTile(
                   title: Text(event.name),
-                  subtitle: Text('${_formatDate(event.date)} - ${event.status}'),
+                  subtitle: Text(
+                      '${event.date != null ? _formatDate(event.date!) : "Sin fecha"} - ${event.status}'),
                   trailing: const Icon(Icons.chevron_right),
                   onTap: () {
                     Navigator.push(

--- a/Backend/frontend/lib/features/products/presentation/screens/product_detail_screen.dart
+++ b/Backend/frontend/lib/features/products/presentation/screens/product_detail_screen.dart
@@ -5,7 +5,7 @@ import 'package:frontend/core/design_system.dart';
 import 'package:frontend/core/app_colors.dart';
 import '../products_provider.dart';
 import '../../data/product_models.dart';
-import '../../../active_event/presentation/active_event_provider.dart';
+import '../widgets/add_to_event_sheet.dart';
 import '../reviews_provider.dart';
 import '../../../events/presentation/events_provider.dart';
 
@@ -18,7 +18,6 @@ class ProductDetailScreen extends StatefulWidget {
 
 class _ProductDetailScreenState extends State<ProductDetailScreen>
     with TickerProviderStateMixin {
-  int _qty = 1;
   bool _descExpanded = false;
   int _selectedVariantIdx = 0;
   late final TabController _tabCtrl;
@@ -1067,60 +1066,17 @@ class _ProductDetailScreenState extends State<ProductDetailScreen>
                   color: t.textMuted, size: 20),
             ),
           ),
-          const SizedBox(width: 10),
-          // Qty selector
-          Container(
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: t.borderFaint),
-            ),
-            child: Row(children: [
-              _qtyBtn(Icons.remove_rounded, t,
-                  onTap: _qty > 1 ? () => setState(() => _qty--) : null),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text('$_qty',
-                    style: GoogleFonts.outfit(
-                        fontSize: 18, fontWeight: FontWeight.w800,
-                        color: t.textPrimary)),
-              ),
-              _qtyBtn(Icons.add_rounded, t,
-                  onTap: () => setState(() => _qty++)),
-            ]),
-          ),
-          const SizedBox(width: 14),
+          const SizedBox(width: 12),
+          // Full-width "Agregar a mi evento" CTA — opens the qty modal.
           Expanded(
             child: GestureDetector(
-              onTap: () async {
+              onTap: () {
                 if (variant == null) return;
-                try {
-                  await context.read<ActiveEventProvider>().addItem(
-                        product,
-                        variant: variant,
-                        quantity: _qty,
-                      );
-                  if (!mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                    content: Row(children: [
-                      const Icon(Icons.celebration_rounded,
-                          color: Colors.white, size: 18),
-                      const SizedBox(width: 8),
-                      Text('Agregado a tu evento',
-                          style: GoogleFonts.dmSans(
-                              fontWeight: FontWeight.w600)),
-                    ]),
-                    backgroundColor: AppColors.teal,
-                    behavior: SnackBarBehavior.floating,
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12)),
-                  ));
-                } catch (e) {
-                  if (!mounted) return;
-                  ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-                    content: Text('Error: $e'),
-                    backgroundColor: AppColors.coral,
-                  ));
-                }
+                AddToEventSheet.show(
+                  context: context,
+                  product: product,
+                  variant: variant,
+                );
               },
               child: Container(
                 height: 54,
@@ -1133,47 +1089,23 @@ class _ProductDetailScreenState extends State<ProductDetailScreen>
                         blurRadius: 16, offset: const Offset(0, 6)),
                   ],
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(Icons.celebration_rounded,
-                          color: Colors.white, size: 20),
-                      const SizedBox(width: 10),
-                      Flexible(
-                        child: FittedBox(
-                          fit: BoxFit.scaleDown,
-                          child: Text('Agregar a mi evento',
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: GoogleFonts.dmSans(
-                                  fontSize: 16,
-                                  fontWeight: FontWeight.w800,
-                                  color: Colors.white)),
-                        ),
-                      ),
-                    ],
-                  ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.celebration_rounded,
+                        color: Colors.white, size: 20),
+                    const SizedBox(width: 10),
+                    Text('Agregar a mi evento',
+                        style: GoogleFonts.dmSans(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w800,
+                            color: Colors.white)),
+                  ],
                 ),
               ),
             ),
           ),
         ]),
-      ),
-    );
-  }
-
-  Widget _qtyBtn(IconData icon, RfTheme t, {VoidCallback? onTap}) {
-    final on = onTap != null;
-    return GestureDetector(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.all(12),
-        child: Icon(icon,
-            color: on ? t.textPrimary : t.textDim.withOpacity(0.3),
-            size: 20),
       ),
     );
   }

--- a/Backend/frontend/lib/features/products/presentation/screens/product_detail_screen.dart
+++ b/Backend/frontend/lib/features/products/presentation/screens/product_detail_screen.dart
@@ -5,7 +5,7 @@ import 'package:frontend/core/design_system.dart';
 import 'package:frontend/core/app_colors.dart';
 import '../products_provider.dart';
 import '../../data/product_models.dart';
-import '../../../shop/presentation/cart_provider.dart';
+import '../../../active_event/presentation/active_event_provider.dart';
 import '../reviews_provider.dart';
 import '../../../events/presentation/events_provider.dart';
 
@@ -1094,15 +1094,18 @@ class _ProductDetailScreenState extends State<ProductDetailScreen>
               onTap: () async {
                 if (variant == null) return;
                 try {
-                  await context.read<CartProvider>().addItem(
-                      product.id, variant.id, _qty);
+                  await context.read<ActiveEventProvider>().addItem(
+                        product,
+                        variant: variant,
+                        quantity: _qty,
+                      );
                   if (!mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                     content: Row(children: [
-                      const Icon(Icons.check_circle_rounded,
+                      const Icon(Icons.celebration_rounded,
                           color: Colors.white, size: 18),
                       const SizedBox(width: 8),
-                      Text('Agregado al carrito',
+                      Text('Agregado a tu evento',
                           style: GoogleFonts.dmSans(
                               fontWeight: FontWeight.w600)),
                     ]),
@@ -1130,17 +1133,29 @@ class _ProductDetailScreenState extends State<ProductDetailScreen>
                         blurRadius: 16, offset: const Offset(0, 6)),
                   ],
                 ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    const Icon(Icons.shopping_cart_outlined,
-                        color: Colors.white, size: 20),
-                    const SizedBox(width: 10),
-                    Text('Añadir al carrito',
-                        style: GoogleFonts.dmSans(
-                            fontSize: 16, fontWeight: FontWeight.w800,
-                            color: Colors.white)),
-                  ],
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.celebration_rounded,
+                          color: Colors.white, size: 20),
+                      const SizedBox(width: 10),
+                      Flexible(
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Text('Agregar a mi evento',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: GoogleFonts.dmSans(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w800,
+                                  color: Colors.white)),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/Backend/frontend/lib/features/products/presentation/screens/products_list_screen.dart
+++ b/Backend/frontend/lib/features/products/presentation/screens/products_list_screen.dart
@@ -7,9 +7,9 @@ import 'package:frontend/core/app_colors.dart';
 import '../products_provider.dart';
 import '../../../categories/presentation/categories_provider.dart';
 import '../../../shell/main_shell.dart';
+import '../../../active_event/presentation/active_event_provider.dart';
+import '../../../active_event/presentation/screens/mi_evento_screen.dart';
 import '../../../categories/presentation/screens/categories_screen.dart';
-import '../../../shop/presentation/cart_provider.dart';
-import '../../../shop/presentation/screens/cart_screen.dart';
 import '../../data/product_models.dart';
 import '../widgets/product_card.dart';
 import 'product_detail_screen.dart';
@@ -62,6 +62,9 @@ class _ProductsListScreenState extends State<ProductsListScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<ProductsProvider>().fetchProducts(refresh: true);
       context.read<CategoriesProvider>().fetchCategories();
+      // Hydrate the active draft event so the top-bar badge shows the
+      // correct count even on first paint.
+      context.read<ActiveEventProvider>().fetch();
     });
   }
 
@@ -234,25 +237,27 @@ class _ProductsListScreenState extends State<ProductsListScreen> {
             _topBarIcon(Icons.notifications_rounded, t, () {},
                 showDot: true, size: 48),
             const SizedBox(width: 10),
-            Consumer<CartProvider>(
-              builder: (context, cart, _) {
+            // "Mi evento" entry — replaces the old cart icon. The badge
+            // counts items in the user's draft (active) event.
+            Consumer<ActiveEventProvider>(
+              builder: (context, active, _) {
                 return Stack(
                   clipBehavior: Clip.none,
                   children: [
                     _topBarIcon(
-                      Icons.shopping_cart_outlined,
+                      Icons.celebration_rounded,
                       t,
                       () {
                         Navigator.push(
                             context,
                             MaterialPageRoute(
-                                builder: (_) => const CartScreen()));
+                                builder: (_) => const MiEventoScreen()));
                       },
                       size: 54,
                       iconSize: 26,
                       elevated: true,
                     ),
-                    if (cart.itemCount > 0)
+                    if (active.itemCount > 0)
                       Positioned(
                         right: -2, top: -2,
                         child: Container(
@@ -266,7 +271,7 @@ class _ProductsListScreenState extends State<ProductsListScreen> {
                                 width: 2),
                           ),
                           child: Text(
-                            '${cart.itemCount}',
+                            '${active.itemCount}',
                             style: GoogleFonts.dmSans(
                                 fontSize: 11,
                                 fontWeight: FontWeight.w800,

--- a/Backend/frontend/lib/features/products/presentation/widgets/add_to_event_sheet.dart
+++ b/Backend/frontend/lib/features/products/presentation/widgets/add_to_event_sheet.dart
@@ -1,0 +1,461 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+import 'package:frontend/core/design_system.dart';
+import 'package:frontend/core/app_colors.dart';
+
+import '../../../active_event/presentation/active_event_provider.dart';
+import '../../data/product_models.dart';
+
+/// Modal bottom sheet that lets the user pick a quantity and add the
+/// product to their active (draft) event.
+///
+/// Designed for narrow viewports — the product detail screen's bottom bar
+/// no longer carries a quantity stepper because it didn't fit on small
+/// screens. The full-width CTA there opens this sheet instead.
+///
+/// Usage:
+/// ```dart
+/// AddToEventSheet.show(
+///   context: context,
+///   product: product,
+///   variant: selectedVariant,
+/// );
+/// ```
+class AddToEventSheet extends StatefulWidget {
+  final Product product;
+  final ProductVariant? variant;
+
+  const AddToEventSheet({
+    super.key,
+    required this.product,
+    required this.variant,
+  });
+
+  /// Convenience launcher. Opens the sheet, returns once it closes.
+  static Future<void> show({
+    required BuildContext context,
+    required Product product,
+    required ProductVariant? variant,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      barrierColor: Colors.black.withOpacity(0.55),
+      builder: (_) => AddToEventSheet(
+        product: product,
+        variant: variant,
+      ),
+    );
+  }
+
+  @override
+  State<AddToEventSheet> createState() => _AddToEventSheetState();
+}
+
+class _AddToEventSheetState extends State<AddToEventSheet> {
+  int _qty = 1;
+  bool _submitting = false;
+
+  void _inc() => setState(() => _qty++);
+  void _dec() {
+    if (_qty > 1) setState(() => _qty--);
+  }
+
+  Future<void> _submit() async {
+    if (widget.variant == null || _submitting) return;
+    setState(() => _submitting = true);
+
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final provider = context.read<ActiveEventProvider>();
+    final productName = widget.product.nameTemplate;
+
+    try {
+      await provider.addItem(
+        widget.product,
+        variant: widget.variant,
+        quantity: _qty,
+      );
+      navigator.pop();
+      messenger.showSnackBar(SnackBar(
+        content: Row(children: [
+          const Icon(Icons.celebration_rounded,
+              color: Colors.white, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '$_qty × $productName en tu evento',
+              style: GoogleFonts.dmSans(fontWeight: FontWeight.w600),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ]),
+        backgroundColor: AppColors.teal,
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12)),
+      ));
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _submitting = false);
+      messenger.showSnackBar(SnackBar(
+        content: Text('Error: $e'),
+        backgroundColor: AppColors.coral,
+      ));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = RfTheme.of(context);
+    final variant = widget.variant;
+    final unitPrice = variant?.rentalPrice ?? 0;
+    final total = unitPrice * _qty;
+    final imageUrl = variant?.imageUrl;
+    final variantLabel = variant?.name;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: t.isDark ? t.card : Colors.white,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.hotPink.withOpacity(0.08),
+            blurRadius: 32,
+            offset: const Offset(0, -8),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+            24, 12, 24,
+            20 + MediaQuery.of(context).viewInsets.bottom,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Drag handle
+              Center(
+                child: Container(
+                  width: 44, height: 4,
+                  decoration: BoxDecoration(
+                    color: t.textDim.withOpacity(0.3),
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              // Product header card
+              _ProductHeader(
+                imageUrl: imageUrl,
+                name: widget.product.nameTemplate,
+                variantLabel: variantLabel,
+                unitPrice: unitPrice,
+                t: t,
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Text(
+                    'Cantidad',
+                    style: GoogleFonts.dmSans(
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                      color: t.textMuted,
+                      letterSpacing: 0.4,
+                    ),
+                  ),
+                  const Spacer(),
+                  // Compact pill-shaped quantity stepper
+                  _QtyPicker(
+                    quantity: _qty,
+                    onIncrement: _inc,
+                    onDecrement: _dec,
+                    t: t,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 22),
+              // Live total — gradient
+              _TotalRow(total: total, t: t),
+              const SizedBox(height: 22),
+              // Primary CTA
+              RfLuxeButton(
+                label: _submitting ? 'Agregando…' : 'Agregar a mi evento',
+                onTap: _submitting ? () {} : _submit,
+                loading: _submitting,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ── Product header ─────────────────────────────────────────────────────────
+
+class _ProductHeader extends StatelessWidget {
+  final String? imageUrl;
+  final String name;
+  final String? variantLabel;
+  final double unitPrice;
+  final RfTheme t;
+
+  const _ProductHeader({
+    required this.imageUrl,
+    required this.name,
+    required this.variantLabel,
+    required this.unitPrice,
+    required this.t,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: t.isDark
+            ? Colors.white.withOpacity(0.04)
+            : Colors.black.withOpacity(0.025),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(14),
+            child: SizedBox(
+              width: 60, height: 60,
+              child: imageUrl != null && imageUrl!.isNotEmpty
+                  ? Image.network(
+                      imageUrl!,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => Container(
+                        color: AppColors.hotPink.withOpacity(0.08),
+                        child: const Icon(
+                          Icons.image_not_supported_rounded,
+                          color: AppColors.hotPink,
+                        ),
+                      ),
+                    )
+                  : Container(
+                      color: AppColors.hotPink.withOpacity(0.08),
+                      child: const Icon(
+                        Icons.image_not_supported_rounded,
+                        color: AppColors.hotPink,
+                      ),
+                    ),
+            ),
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: GoogleFonts.outfit(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w800,
+                    color: t.textPrimary,
+                    height: 1.2,
+                  ),
+                ),
+                if (variantLabel != null && variantLabel!.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    variantLabel!,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: GoogleFonts.dmSans(
+                      fontSize: 12,
+                      color: t.textMuted,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 4),
+                Text(
+                  'RD\$ ${unitPrice.toStringAsFixed(0)} c/u',
+                  style: GoogleFonts.dmSans(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                    color: t.textDim,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Quantity picker ────────────────────────────────────────────────────────
+
+/// Compact pill-shaped quantity stepper. Sits inline next to the
+/// "Cantidad" label so it doesn't dominate the modal vertically.
+class _QtyPicker extends StatelessWidget {
+  final int quantity;
+  final VoidCallback onIncrement;
+  final VoidCallback onDecrement;
+  final RfTheme t;
+
+  const _QtyPicker({
+    required this.quantity,
+    required this.onIncrement,
+    required this.onDecrement,
+    required this.t,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final canDecrement = quantity > 1;
+    return Container(
+      padding: const EdgeInsets.all(4),
+      decoration: BoxDecoration(
+        color: t.isDark
+            ? Colors.white.withOpacity(0.05)
+            : Colors.black.withOpacity(0.04),
+        borderRadius: BorderRadius.circular(40),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _QtyCircleBtn(
+            icon: Icons.remove_rounded,
+            enabled: canDecrement,
+            onTap: onDecrement,
+            t: t,
+          ),
+          SizedBox(
+            width: 56,
+            child: Text(
+              '$quantity',
+              textAlign: TextAlign.center,
+              style: GoogleFonts.outfit(
+                fontSize: 22,
+                fontWeight: FontWeight.w800,
+                color: t.textPrimary,
+                height: 1,
+              ),
+            ),
+          ),
+          _QtyCircleBtn(
+            icon: Icons.add_rounded,
+            enabled: true,
+            onTap: onIncrement,
+            t: t,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _QtyCircleBtn extends StatelessWidget {
+  final IconData icon;
+  final bool enabled;
+  final VoidCallback onTap;
+  final RfTheme t;
+
+  const _QtyCircleBtn({
+    required this.icon,
+    required this.enabled,
+    required this.onTap,
+    required this.t,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: enabled ? onTap : null,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: enabled
+              ? const LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: [AppColors.violet, AppColors.hotPink],
+                )
+              : null,
+          color: enabled
+              ? null
+              : (t.isDark
+                  ? Colors.white.withOpacity(0.04)
+                  : Colors.black.withOpacity(0.04)),
+          boxShadow: enabled
+              ? [
+                  BoxShadow(
+                    color: AppColors.hotPink.withOpacity(0.28),
+                    blurRadius: 10,
+                    offset: const Offset(0, 4),
+                  ),
+                ]
+              : null,
+        ),
+        child: Icon(
+          icon,
+          color: enabled
+              ? Colors.white
+              : t.textDim.withOpacity(0.5),
+          size: 18,
+        ),
+      ),
+    );
+  }
+}
+
+// ── Total row ──────────────────────────────────────────────────────────────
+
+class _TotalRow extends StatelessWidget {
+  final double total;
+  final RfTheme t;
+  const _TotalRow({required this.total, required this.t});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(
+          'Total',
+          style: GoogleFonts.dmSans(
+            fontSize: 14,
+            fontWeight: FontWeight.w600,
+            color: t.textMuted,
+          ),
+        ),
+        ShaderMask(
+          shaderCallback: (b) => const LinearGradient(colors: [
+            AppColors.violet,
+            AppColors.hotPink,
+          ]).createShader(b),
+          child: Text(
+            'RD\$ ${total.toStringAsFixed(0)}',
+            style: GoogleFonts.outfit(
+              fontSize: 28,
+              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              height: 1,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/Backend/frontend/lib/features/products/presentation/widgets/product_card.dart
+++ b/Backend/frontend/lib/features/products/presentation/widgets/product_card.dart
@@ -6,12 +6,15 @@ import 'package:frontend/core/app_colors.dart';
 
 import '../../data/product_models.dart';
 import '../screens/product_detail_screen.dart';
+import '../../../active_event/presentation/active_event_provider.dart';
 import '../../../favorites/presentation/favorites_provider.dart';
 
 /// Shared product card used by the catalog and the favorites screen.
 ///
-/// Includes a functional favorite (heart) button that toggles via
-/// [FavoritesProvider]. Tap on the heart does not bubble up to the card tap.
+/// - Heart icon toggles via [FavoritesProvider].
+/// - "+" icon adds the product to the user's draft event via
+///   [ActiveEventProvider]. Both interactions stop event propagation so
+///   the card tap (open detail) does not fire on the same gesture.
 class ProductCard extends StatelessWidget {
   final Product product;
   final VoidCallback? onAddToCart;
@@ -265,7 +268,25 @@ class ProductCard extends StatelessWidget {
                       ),
                       GestureDetector(
                         behavior: HitTestBehavior.opaque,
-                        onTap: onAddToCart,
+                        onTap: () async {
+                          // External hook wins so callers (e.g. detail
+                          // page or A/B branches) can override behavior.
+                          if (onAddToCart != null) {
+                            onAddToCart!();
+                            return;
+                          }
+                          await context
+                              .read<ActiveEventProvider>()
+                              .addItem(product);
+                          if (!context.mounted) return;
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              duration: const Duration(seconds: 2),
+                              content: Text(
+                                  'Agregado a tu evento: ${product.nameTemplate}'),
+                            ),
+                          );
+                        },
                         child: Container(
                           width: 28,
                           height: 28,

--- a/Backend/frontend/lib/main.dart
+++ b/Backend/frontend/lib/main.dart
@@ -32,6 +32,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'core/services/firebase_service.dart';
 import 'core/services/hive_service.dart';
 import 'core/services/sync_service.dart';
+import 'features/active_event/presentation/active_event_provider.dart';
 import 'features/ai_assistant/presentation/assistant_provider.dart';
 import 'features/favorites/presentation/favorites_provider.dart';
 
@@ -84,6 +85,7 @@ Future<void> main() async {
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => ProductsProvider()),
         ChangeNotifierProvider(create: (_) => CartProvider()),
+        ChangeNotifierProvider(create: (_) => ActiveEventProvider()),
         ChangeNotifierProvider(create: (_) => FavoritesProvider()),
         ChangeNotifierProvider(create: (_) => CategoriesProvider()),
         ChangeNotifierProvider(create: (_) => ProfileProvider()),

--- a/Backend/internal/store/events.go
+++ b/Backend/internal/store/events.go
@@ -16,6 +16,10 @@ type EventStore struct {
 }
 
 func (s *EventStore) Create(ctx context.Context, event *models.Event) error {
+	if event.Status == "" {
+		event.Status = models.EventStatusDraft
+	}
+
 	query := `
 		INSERT INTO events (user_id, name, date, location, guest_count, budget, status, additional_costs, admin_notes, payment_status, payment_method, paid_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
@@ -47,6 +51,66 @@ func (s *EventStore) Create(ctx context.Context, event *models.Event) error {
 	}
 
 	return nil
+}
+
+// GetOrCreateDraft returns the user's current draft event. If they don't
+// have one yet, an empty draft is created and returned.
+//
+// A user is guaranteed to have at most one draft at a time thanks to the
+// `events_user_active_draft` partial unique index. The race between two
+// concurrent requests is resolved by ON CONFLICT — both end up returning
+// the same row.
+func (s *EventStore) GetOrCreateDraft(ctx context.Context, userID uuid.UUID) (*models.Event, error) {
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeoutDuration)
+	defer cancel()
+
+	// Try to find an existing draft first.
+	const selectQuery = `
+		SELECT id, user_id, name, date, location, guest_count, budget, status,
+		       additional_costs, admin_notes, payment_status, payment_method,
+		       paid_at, created_at, updated_at
+		FROM events
+		WHERE user_id = $1 AND status = 'draft'
+		LIMIT 1
+	`
+
+	scan := func(row *sql.Row, ev *models.Event) error {
+		return row.Scan(
+			&ev.ID, &ev.UserID, &ev.Name, &ev.Date, &ev.Location,
+			&ev.GuestCount, &ev.Budget, &ev.Status,
+			&ev.AdditionalCosts, &ev.AdminNotes,
+			&ev.PaymentStatus, &ev.PaymentMethod, &ev.PaidAt,
+			&ev.CreatedAt, &ev.UpdatedAt,
+		)
+	}
+
+	var event models.Event
+	err := scan(s.db.QueryRowContext(ctx, selectQuery, userID), &event)
+	if err == nil {
+		return &event, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	// No draft yet — create one. The partial unique index ensures that if
+	// a concurrent request beats us to it we just read whatever ended up
+	// being inserted. Empty defaults are explicit so the model's non-nullable
+	// string fields scan cleanly when we re-read the row.
+	const insertQuery = `
+		INSERT INTO events (user_id, name, location, status, admin_notes, payment_status)
+		VALUES ($1, '', '', 'draft', '', '')
+		ON CONFLICT (user_id) WHERE status = 'draft' DO NOTHING
+	`
+	if _, err := s.db.ExecContext(ctx, insertQuery, userID); err != nil {
+		return nil, err
+	}
+
+	// Re-read whatever draft now exists for this user.
+	if err := scan(s.db.QueryRowContext(ctx, selectQuery, userID), &event); err != nil {
+		return nil, err
+	}
+	return &event, nil
 }
 
 func (s *EventStore) GetByID(ctx context.Context, id uuid.UUID) (*models.Event, error) {
@@ -227,28 +291,78 @@ func (s *EventStore) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// AddItem upserts an event item. If a line for the same (event, article,
+// variant) tuple already exists, the quantity is incremented; otherwise
+// a new row is inserted with the captured price snapshot.
 func (s *EventStore) AddItem(ctx context.Context, item *models.EventItem) error {
-	query := `
-		INSERT INTO event_items (event_id, article_id, quantity)
-		VALUES ($1, $2, $3)
-		RETURNING id, created_at, updated_at
-	`
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeoutDuration)
+	defer cancel()
 
-	err := s.db.QueryRowContext(
-		ctx,
-		query,
-		item.EventID,
-		item.ArticleID,
-		item.Quantity,
-	).Scan(
-		&item.ID,
-		&item.CreatedAt,
-		&item.UpdatedAt,
-	)
-	if err != nil {
+	// Try to find an existing line for this (event, article, variant).
+	const checkQuery = `
+		SELECT id, quantity FROM event_items
+		WHERE event_id = $1
+		  AND article_id = $2
+		  AND ((variant_id IS NULL AND $3::UUID IS NULL) OR variant_id = $3::UUID)
+	`
+	var existingID uuid.UUID
+	var existingQty int
+	err := s.db.QueryRowContext(ctx, checkQuery, item.EventID, item.ArticleID, item.VariantID).
+		Scan(&existingID, &existingQty)
+
+	if err == nil {
+		// Increment the existing line's quantity.
+		const updateQuery = `
+			UPDATE event_items
+			SET quantity = quantity + $1, updated_at = NOW()
+			WHERE id = $2
+			RETURNING id, quantity, created_at, updated_at
+		`
+		return s.db.QueryRowContext(ctx, updateQuery, item.Quantity, existingID).
+			Scan(&item.ID, &item.Quantity, &item.CreatedAt, &item.UpdatedAt)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
 		return err
 	}
 
+	// New line — insert.
+	const insertQuery = `
+		INSERT INTO event_items (event_id, article_id, variant_id, quantity, price_snapshot)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, created_at, updated_at
+	`
+	return s.db.QueryRowContext(
+		ctx,
+		insertQuery,
+		item.EventID,
+		item.ArticleID,
+		item.VariantID,
+		item.Quantity,
+		item.PriceSnapshot,
+	).Scan(&item.ID, &item.CreatedAt, &item.UpdatedAt)
+}
+
+// UpdateItemQuantity sets the absolute quantity for a given event item.
+func (s *EventStore) UpdateItemQuantity(ctx context.Context, itemID uuid.UUID, quantity int) error {
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeoutDuration)
+	defer cancel()
+
+	const query = `
+		UPDATE event_items
+		SET quantity = $1, updated_at = NOW()
+		WHERE id = $2
+	`
+	res, err := s.db.ExecContext(ctx, query, quantity, itemID)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
 	return nil
 }
 
@@ -273,12 +387,24 @@ func (s *EventStore) RemoveItem(ctx context.Context, eventID, startID uuid.UUID)
 }
 
 func (s *EventStore) GetItems(ctx context.Context, eventID uuid.UUID) ([]models.EventItem, error) {
-	query := `
-		SELECT ei.id, ei.event_id, ei.article_id, ei.quantity, ei.created_at, ei.updated_at,
-		       a.id, a.name_template, a.description_template, a.category_id, a.is_active, a.type,
-               (SELECT v.rental_price FROM article_variants v WHERE v.article_id = a.id LIMIT 1) as price
+	ctx, cancel := context.WithTimeout(ctx, QueryTimeoutDuration)
+	defer cancel()
+
+	const query = `
+		SELECT ei.id, ei.event_id, ei.article_id, ei.variant_id, ei.quantity,
+		       ei.price_snapshot, ei.created_at, ei.updated_at,
+		       a.id, a.name_template, a.description_template, a.category_id,
+		       a.is_active, COALESCE(a.type, ''),
+		       v.id, v.sku, v.name, v.image_url, v.rental_price, v.sale_price, v.stock,
+		       COALESCE(
+		           ei.price_snapshot,
+		           v.rental_price,
+		           (SELECT v2.rental_price FROM article_variants v2
+		            WHERE v2.article_id = a.id ORDER BY v2.created_at ASC LIMIT 1)
+		       ) AS effective_price
 		FROM event_items ei
 		JOIN articles a ON ei.article_id = a.id
+		LEFT JOIN article_variants v ON ei.variant_id = v.id
 		WHERE ei.event_id = $1
 		ORDER BY ei.created_at DESC
 	`
@@ -289,15 +415,29 @@ func (s *EventStore) GetItems(ctx context.Context, eventID uuid.UUID) ([]models.
 	}
 	defer rows.Close()
 
-	var items []models.EventItem
+	items := make([]models.EventItem, 0)
 	for rows.Next() {
 		var item models.EventItem
 		item.Article = &models.Article{}
-		err := rows.Scan(
+
+		var (
+			variantID        sql.NullString
+			variantSku       sql.NullString
+			variantName      sql.NullString
+			variantImage     sql.NullString
+			variantRental    sql.NullFloat64
+			variantSale      sql.NullFloat64
+			variantStock     sql.NullInt64
+			effectivePrice   sql.NullFloat64
+		)
+
+		if err := rows.Scan(
 			&item.ID,
 			&item.EventID,
 			&item.ArticleID,
+			&item.VariantID,
 			&item.Quantity,
+			&item.PriceSnapshot,
 			&item.CreatedAt,
 			&item.UpdatedAt,
 			&item.Article.ID,
@@ -306,11 +446,43 @@ func (s *EventStore) GetItems(ctx context.Context, eventID uuid.UUID) ([]models.
 			&item.Article.CategoryID,
 			&item.Article.IsActive,
 			&item.Article.Type,
-			&item.Price,
-		)
-		if err != nil {
+			&variantID, &variantSku, &variantName, &variantImage,
+			&variantRental, &variantSale, &variantStock,
+			&effectivePrice,
+		); err != nil {
 			return nil, err
 		}
+
+		if variantID.Valid {
+			vid, _ := uuid.Parse(variantID.String)
+			variant := models.ArticleVariant{
+				ID:        vid,
+				ArticleID: item.ArticleID,
+				Sku:       variantSku.String,
+				Name:      variantName.String,
+			}
+			if variantImage.Valid {
+				img := variantImage.String
+				variant.ImageURL = &img
+			}
+			if variantRental.Valid {
+				variant.RentalPrice = variantRental.Float64
+			}
+			if variantSale.Valid {
+				sp := variantSale.Float64
+				variant.SalePrice = &sp
+			}
+			if variantStock.Valid {
+				variant.Stock = int(variantStock.Int64)
+			}
+			item.Variant = &variant
+		}
+
+		if effectivePrice.Valid {
+			price := effectivePrice.Float64
+			item.Price = &price
+		}
+
 		items = append(items, item)
 	}
 

--- a/Backend/internal/store/mocks/mocks.go
+++ b/Backend/internal/store/mocks/mocks.go
@@ -167,6 +167,14 @@ func (m *EventStore) GetByUserID(ctx context.Context, id uuid.UUID) ([]models.Ev
 	return args.Get(0).([]models.Event), args.Error(1)
 }
 
+func (m *EventStore) GetOrCreateDraft(ctx context.Context, userID uuid.UUID) (*models.Event, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Event), args.Error(1)
+}
+
 func (m *EventStore) GetAll(ctx context.Context) ([]models.Event, error) {
 	args := m.Called(ctx)
 	if args.Get(0) == nil {
@@ -187,6 +195,11 @@ func (m *EventStore) Delete(ctx context.Context, id uuid.UUID) error {
 
 func (m *EventStore) AddItem(ctx context.Context, item *models.EventItem) error {
 	args := m.Called(ctx, item)
+	return args.Error(0)
+}
+
+func (m *EventStore) UpdateItemQuantity(ctx context.Context, itemID uuid.UUID, quantity int) error {
+	args := m.Called(ctx, itemID, quantity)
 	return args.Error(0)
 }
 

--- a/Backend/internal/store/models/event.go
+++ b/Backend/internal/store/models/event.go
@@ -6,17 +6,31 @@ import (
 	"github.com/google/uuid"
 )
 
+// Event statuses. `EventStatusDraft` is the new default — a user always has
+// at most one draft event acting as their "active event" while they browse
+// the catalog.
+const (
+	EventStatusDraft     = "draft"
+	EventStatusPlanning  = "planning" // legacy, kept for backwards compat
+	EventStatusRequested = "requested"
+	EventStatusAdjusted  = "adjusted"
+	EventStatusConfirmed = "confirmed"
+	EventStatusPaid      = "paid"
+	EventStatusCompleted = "completed"
+	EventStatusCancelled = "cancelled"
+)
+
 type Event struct {
 	ID              uuid.UUID  `json:"id"`
 	UserID          uuid.UUID  `json:"user_id"`
 	Name            string     `json:"name"`
-	Date            time.Time  `json:"date"`
+	Date            *time.Time `json:"date,omitempty"`
 	Location        string     `json:"location"`
 	GuestCount      int        `json:"guest_count"`
 	Budget          float64    `json:"budget"`
 	AdditionalCosts float64    `json:"additional_costs"`
 	AdminNotes      string     `json:"admin_notes"`
-	Status          string     `json:"status"` // planning, requested, adjusted, confirmed, paid, completed
+	Status          string     `json:"status"`
 	PaymentStatus   string     `json:"payment_status"`
 	PaymentMethod   *string    `json:"payment_method"`
 	PaidAt          *time.Time `json:"paid_at"`
@@ -24,6 +38,9 @@ type Event struct {
 	UpdatedAt       string     `json:"updated_at"`
 }
 
+// CreateEventPayload still requires name and date because the explicit
+// "create event" flow is for users who already know what they want.
+// The implicit draft creation goes through GetOrCreateDraft instead.
 type CreateEventPayload struct {
 	Name       string  `json:"name" validate:"required,max=255"`
 	Date       string  `json:"date" validate:"required"` // ISO8601 string
@@ -40,7 +57,7 @@ type UpdateEventPayload struct {
 	Budget          *float64 `json:"budget" validate:"omitempty,min=0"`
 	AdditionalCosts *float64 `json:"additional_costs" validate:"omitempty,min=0"`
 	AdminNotes      *string  `json:"admin_notes" validate:"omitempty"`
-	Status          *string  `json:"status" validate:"omitempty,oneof=planning requested adjusted confirmed paid completed"`
+	Status          *string  `json:"status" validate:"omitempty,oneof=draft planning requested adjusted confirmed paid completed cancelled"`
 	PaymentStatus   *string  `json:"payment_status" validate:"omitempty"`
 	PaymentMethod   *string  `json:"payment_method" validate:"omitempty"`
 }

--- a/Backend/internal/store/models/event_item.go
+++ b/Backend/internal/store/models/event_item.go
@@ -7,14 +7,17 @@ import (
 )
 
 type EventItem struct {
-	ID        uuid.UUID `json:"id"`
-	EventID   uuid.UUID `json:"event_id"`
-	ArticleID uuid.UUID `json:"article_id"`
-	Quantity  int       `json:"quantity"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID            uuid.UUID  `json:"id"`
+	EventID       uuid.UUID  `json:"event_id"`
+	ArticleID     uuid.UUID  `json:"article_id"`
+	VariantID     *uuid.UUID `json:"variant_id,omitempty"`
+	Quantity      int        `json:"quantity"`
+	PriceSnapshot *float64   `json:"price_snapshot,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
 
-	// Optional: Include Article details if joined
-	Article *Article `json:"article,omitempty"`
-	Price   *float64 `json:"price,omitempty"`
+	// Optional: Include Article + Variant details if joined
+	Article *Article        `json:"article,omitempty"`
+	Variant *ArticleVariant `json:"variant,omitempty"`
+	Price   *float64        `json:"price,omitempty"`
 }

--- a/Backend/internal/store/store.go
+++ b/Backend/internal/store/store.go
@@ -76,9 +76,15 @@ type Storage struct {
 		Create(context.Context, *models.Event) error
 		GetByID(context.Context, uuid.UUID) (*models.Event, error)
 		GetByUserID(context.Context, uuid.UUID) ([]models.Event, error)
+		// GetOrCreateDraft returns the user's current draft event,
+		// creating an empty one if none exists. This is the entry point
+		// for the catalog "+" button — every user always has exactly
+		// one draft acting as their active event.
+		GetOrCreateDraft(context.Context, uuid.UUID) (*models.Event, error)
 		Update(context.Context, *models.Event) error
 		Delete(context.Context, uuid.UUID) error
 		AddItem(context.Context, *models.EventItem) error
+		UpdateItemQuantity(context.Context, uuid.UUID, int) error
 		RemoveItem(context.Context, uuid.UUID, uuid.UUID) error
 		GetItems(context.Context, uuid.UUID) ([]models.EventItem, error)
 		GetDebrief(context.Context, uuid.UUID) (*models.EventDebrief, error)

--- a/Backend/internal/worker/notification_sender.go
+++ b/Backend/internal/worker/notification_sender.go
@@ -59,6 +59,12 @@ func (w *NotificationSender) processNotifications(ctx context.Context) {
 	}
 
 	for _, event := range events {
+		// Drafts (and any other event without a date) can't trigger
+		// date-based notifications.
+		if event.Date == nil {
+			continue
+		}
+
 		// 1. Pre-event reminder
 		if (event.Status == "confirmed" || event.Status == "paid") &&
 			event.Date.After(now) && event.Date.Before(reminderThreshold) {


### PR DESCRIPTION
## Summary

Replaces the cart concept with an "active event" the user is building.
Each user always has at most one **draft event** that acts as their
working basket while they browse the catalog. This is the first half
of the work — phases 1-3 of the 5-phase plan.

This PR is **safe to merge incrementally**: the legacy CartProvider /
CartScreen / cart_items table all stay in place. The catalog and the
product detail now write to the new draft, but nothing in the legacy
flow breaks.

The remaining phases (data backfill of existing carts → drafts and
removal of all the cart code/tables) will land in a follow-up PR.

### Phase 1 — Backend draft events
- Migration `000043` makes `events.date` nullable, sets the default
  status to `draft`, adds a CHECK constraint enumerating legal
  statuses, and a partial unique index that enforces "one draft per
  user"
- `event_items` gains `variant_id` + `price_snapshot` (parity with
  cart_items) and the old `(event, article)` UNIQUE is replaced with
  `(event, article, variant)` so two variants of the same article
  coexist as separate lines
- New store helper `GetOrCreateDraft(userID)` is idempotent and
  race-safe via `ON CONFLICT`
- `EventStore.AddItem` is now an upsert (existing line increments,
  new line inserts with the captured price snapshot)
- New `EventStore.UpdateItemQuantity` for absolute updates
- New routes: `GET /v1/events/active` (returns `{event, items}`,
  creates the draft if needed) and `PATCH /v1/events/active/items/{itemId}`
  (qty 0 deletes)
- Existing `addEventItemHandler` accepts `variant_id` + `price_snapshot`
  and skips availability checks for drafts (no date yet)
- Calendar export and notification worker guard against `nil` dates

### Phase 2 — Frontend data layer + provider
- New `features/active_event/data/{api_service,repository,response}.dart`
- New `ActiveEventProvider` (ChangeNotifier) with `event`, `items`,
  `itemCount`, `lineCount`, `subtotal`, and `addItem / updateQuantity
  / removeItem` with optimistic local updates and rollback on failure
- Registered in `main.dart` alongside the existing `CartProvider`
- `Event.date` becomes nullable across the frontend (events list,
  calendar, pdf export, notifications all updated)

### Phase 3 — UI rewire
- Catalog top bar: cart icon → `celebration_rounded` "Mi evento"
  badge, tap opens the new `MiEventoScreen`
- `ProductCard` quick-add now writes to `ActiveEventProvider`
- Product detail bottom bar: removed the inline qty stepper that was
  overflowing on narrow viewports. The CTA is now full-width and on
  tap opens a new `AddToEventSheet` modal bottom sheet that asks for
  the quantity (compact pill stepper, live total, gradient CTA)
- New `MiEventoScreen` (replaces `CartScreen`): gradient header,
  "no date yet" warning banner when the draft has no date, item
  tiles with image + variant + line total + qty stepper, totals bar
  with "Solicitar cotización" CTA

## Test plan

- [ ] `make migrate-up` applies migration 000043 cleanly
- [ ] `GET /v1/events/active` creates and returns a draft for a fresh user
- [ ] `POST /v1/events/{id}/items` is idempotent: repeated calls with
      the same article+variant increment the existing line
- [ ] `PATCH /v1/events/active/items/{itemId}` with qty 0 removes the line
- [ ] In the app: catalog top bar shows the celebration icon with a
      coral dot when items > 0
- [ ] Tapping "+" on a product card adds the item, badge increments
- [ ] Product detail "Agregar a mi evento" opens a modal, qty selector
      increments, total updates live, confirming closes the modal and
      shows a snackbar
- [ ] "Mi evento" screen shows the items, qty stepper updates them,
      X removes them, pull-to-refresh reloads from backend
- [ ] Existing events list / calendar / event detail still work despite
      `Event.date` being nullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)