### PR TITLE
RF-48: Push Notifications

### DIFF
--- a/Backend/frontend/lib/core/services/firebase_service.dart
+++ b/Backend/frontend/lib/core/services/firebase_service.dart
@@ -1,16 +1,26 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 class FirebaseService {
   static final FirebaseService _instance = FirebaseService._internal();
   factory FirebaseService() => _instance;
   FirebaseService._internal();
 
+  final FlutterLocalNotificationsPlugin _notifications =
+      FlutterLocalNotificationsPlugin();
+
   FirebaseMessaging get _fcm => FirebaseMessaging.instance;
+
+  // Callback for when user taps a notification
+  static void Function(String? screen, String? eventId)? onNotificationTap;
 
   Future<void> initialize() async {
     try {
+      // Initialize local notifications
+      await _initializeNotifications();
+
       // Request permissions for iOS
       NotificationSettings settings = await _fcm.requestPermission(
         alert: true,
@@ -41,6 +51,39 @@ class FirebaseService {
     }
   }
 
+  Future<void> _initializeNotifications() async {
+    // Android settings
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    // iOS settings
+    const iosSettings = DarwinInitializationSettings(
+      requestAlertPermission: false,
+      requestBadgePermission: false,
+      requestSoundPermission: false,
+    );
+
+    const initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: iosSettings,
+    );
+
+    await _notifications.initialize(
+      settings: initSettings,
+      onDidReceiveNotificationResponse: _onNotificationResponse,
+    );
+  }
+
+  void _onNotificationResponse(NotificationResponse response) {
+    // Handle notification tap
+    final payload = response.payload;
+    if (payload != null) {
+      final parts = payload.split('|');
+      final screen = parts.isNotEmpty ? parts[0] : null;
+      final eventId = parts.length > 1 ? parts[1] : null;
+      onNotificationTap?.call(screen, eventId);
+    }
+  }
+
   Future<String?> getToken() async {
     return await _fcm.getToken();
   }
@@ -53,23 +96,103 @@ class FirebaseService {
   }
 
   void setupInteractions() {
-    // Handle foreground messages
+    // Handle foreground messages - show local notification
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-      if (kDebugMode) {
-        print('Got a message whilst in the foreground!');
-        print('Message data: ${message.data}');
-
-        if (message.notification != null) {
-          print('Message also contained a notification: ${message.notification}');
-        }
-      }
+      _showLocalNotification(message);
     });
 
     // Handle messages that opened the app
     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-       if (kDebugMode) {
-        print('A new onMessageOpenedApp event was published!');
-      }
+      _handleNotificationTap(message);
     });
+  }
+
+  Future<void> _showLocalNotification(RemoteMessage message) async {
+    final title = message.notification?.title ?? message.data['title'] ?? 'Rosa Fiesta';
+    final body = message.notification?.body ?? message.data['body'] ?? '';
+    final screen = message.data['screen'];
+    final eventId = message.data['event_id'];
+
+    // Build payload for tap handling
+    String payload = screen ?? 'home';
+    if (eventId != null) {
+      payload += '|$eventId';
+    }
+
+    // Android notification details
+    final androidDetails = AndroidNotificationDetails(
+      'rosa_fiesta_channel',
+      'Rosa Fiesta Notifications',
+      channelDescription: 'Notificaciones de Rosa Fiesta',
+      importance: Importance.high,
+      priority: Priority.high,
+      styleInformation: BigTextStyleInformation(body),
+    );
+
+    // iOS notification details
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    final details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notifications.show(
+      id: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      title: title,
+      body: body,
+      notificationDetails: details,
+      payload: payload,
+    );
+  }
+
+  void _handleNotificationTap(RemoteMessage message) {
+    final screen = message.data['screen'];
+    final eventId = message.data['event_id'];
+    onNotificationTap?.call(screen, eventId);
+  }
+
+  // Method to display a local notification (for testing/manual triggers)
+  Future<void> showNotification({
+    required String title,
+    required String body,
+    String? screen,
+    String? eventId,
+  }) async {
+    String payload = screen ?? 'home';
+    if (eventId != null) {
+      payload += '|$eventId';
+    }
+
+    final androidDetails = AndroidNotificationDetails(
+      'rosa_fiesta_channel',
+      'Rosa Fiesta Notifications',
+      channelDescription: 'Notificaciones de Rosa Fiesta',
+      importance: Importance.high,
+      priority: Priority.high,
+    );
+
+    const iosDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+
+    final details = NotificationDetails(
+      android: androidDetails,
+      iOS: iosDetails,
+    );
+
+    await _notifications.show(
+      id: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      title: title,
+      body: body,
+      notificationDetails: details,
+      payload: payload,
+    );
   }
 }

--- a/Backend/frontend/lib/main.dart
+++ b/Backend/frontend/lib/main.dart
@@ -48,6 +48,7 @@ Future<void> main() async {
     if (!kIsWeb) {
       await Firebase.initializeApp();
       await FirebaseService().initialize();
+      FirebaseService().setupInteractions();
     } else {
       print("Warning: Firebase initialization skipped on Web");
     }


### PR DESCRIPTION
## Summary
Implemented push notification handling:

- FirebaseService now shows local notifications when FCM push is received
- Added `onNotificationTap` callback for handling notification navigation
- Notification payload contains `screen|eventId` format for routing
- Added `showNotification()` method for manual notification testing
- Called `setupInteractions()` in main.dart after Firebase init

## Test plan
- [ ] Receive FCM push notification → verify local notification appears
- [ ] Tap notification → verify callback is invoked with correct payload
- [ ] Call FirebaseService().showNotification() manually → notification appears

## Next steps (not in this PR)
- Wire `onNotificationTap` callback to app navigation layer to actually navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)