### PR TITLE
RF-51: Add tests for favorites, messages, and stats handlers

### DIFF
--- a/Backend/cmd/main/favorites_test.go
+++ b/Backend/cmd/main/favorites_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"Backend/cmd/main/configModels"
+	authMocks "Backend/internal/auth/mocks"
+	storeMocks "Backend/internal/store/mocks"
+	"Backend/internal/store/models"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestListFavorites(t *testing.T) {
+	userID := uuid.New()
+	userIDStr := userID.String()
+
+	tests := []struct {
+		name         string
+		setupMocks   func(*Application)
+		expectedCode int
+	}{
+		{
+			name: "should return list of favorites",
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Once()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "buyer", Level: 1}}, nil).Once()
+
+				favM := app.Store.Favorites.(*storeMocks.FavoritesStore)
+				favM.On("List", mock.Anything, userID).Return([]models.Article{
+					{BaseModel: models.BaseModel{ID: uuid.New()}, NameTemplate: "Table 1"},
+					{BaseModel: models.BaseModel{ID: uuid.New()}, NameTemplate: "Chair 1"},
+				}, nil).Once()
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "should return empty list when no favorites",
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Once()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "buyer", Level: 1}}, nil).Once()
+
+				favM := app.Store.Favorites.(*storeMocks.FavoritesStore)
+				favM.On("List", mock.Anything, userID).Return([]models.Article{}, nil).Once()
+			},
+			expectedCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newTestApplication(t, configModels.Config{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(app)
+			}
+
+			mux := app.Mount()
+			req, _ := http.NewRequest(http.MethodGet, "/v1/favorites", nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+
+			rr := executeRequest(req, mux)
+			checkResponseCode(t, tc.expectedCode, rr)
+		})
+	}
+}
+
+func TestAddFavorite(t *testing.T) {
+	userID := uuid.New()
+	userIDStr := userID.String()
+	articleID := uuid.New()
+
+	tests := []struct {
+		name         string
+		articleID    string
+		setupMocks   func(*Application)
+		expectedCode int
+	}{
+		{
+			name:      "should add favorite successfully",
+			articleID: articleID.String(),
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Once()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "buyer", Level: 1}}, nil).Once()
+
+				favM := app.Store.Favorites.(*storeMocks.FavoritesStore)
+				favM.On("Add", mock.Anything, userID, articleID).Return(nil).Once()
+			},
+			expectedCode: http.StatusCreated,
+		},
+		{
+			name:      "should return 400 for invalid article ID",
+			articleID: "invalid-uuid",
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Once()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "buyer", Level: 1}}, nil).Once()
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newTestApplication(t, configModels.Config{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(app)
+			}
+
+			mux := app.Mount()
+			req, _ := http.NewRequest(http.MethodPost, "/v1/favorites/"+tc.articleID, nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+
+			rr := executeRequest(req, mux)
+			checkResponseCode(t, tc.expectedCode, rr)
+		})
+	}
+}
+
+func TestRemoveFavorite(t *testing.T) {
+	userID := uuid.New()
+	userIDStr := userID.String()
+	articleID := uuid.New()
+
+	tests := []struct {
+		name         string
+		articleID    string
+		setupMocks   func(*Application)
+		expectedCode int
+	}{
+		{
+			name:      "should remove favorite successfully",
+			articleID: articleID.String(),
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Once()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "buyer", Level: 1}}, nil).Once()
+
+				favM := app.Store.Favorites.(*storeMocks.FavoritesStore)
+				favM.On("Remove", mock.Anything, userID, articleID).Return(nil).Once()
+			},
+			expectedCode: http.StatusNoContent,
+		},
+		{
+			name:      "should return 400 for invalid article ID",
+			articleID: "invalid-uuid",
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Once()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "buyer", Level: 1}}, nil).Once()
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newTestApplication(t, configModels.Config{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(app)
+			}
+
+			mux := app.Mount()
+			req, _ := http.NewRequest(http.MethodDelete, "/v1/favorites/"+tc.articleID, nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+
+			rr := executeRequest(req, mux)
+			checkResponseCode(t, tc.expectedCode, rr)
+		})
+	}
+}

--- a/Backend/cmd/main/messages_test.go
+++ b/Backend/cmd/main/messages_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"Backend/cmd/main/configModels"
+	authMocks "Backend/internal/auth/mocks"
+	storeMocks "Backend/internal/store/mocks"
+	"Backend/internal/store/models"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetMessages(t *testing.T) {
+	eventID := uuid.New()
+	userID := uuid.New()
+	userIDStr := userID.String()
+
+	tests := []struct {
+		name         string
+		eventID      string
+		setupMocks   func(*Application)
+		expectedCode int
+	}{
+		{
+			name:    "should return messages for event",
+			eventID: eventID.String(),
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Maybe()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "admin", Level: 5}}, nil).Maybe()
+
+				msgM := app.Store.Messages.(*storeMocks.MessagesStore)
+				msgM.On("GetByEventID", mock.Anything, eventID).Return([]models.EventMessage{
+					{ID: uuid.New(), EventID: eventID, Content: "Hello"},
+				}, nil).Once()
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:    "should return empty list when no messages",
+			eventID: eventID.String(),
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Maybe()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "admin", Level: 5}}, nil).Maybe()
+
+				msgM := app.Store.Messages.(*storeMocks.MessagesStore)
+				msgM.On("GetByEventID", mock.Anything, eventID).Return([]models.EventMessage{}, nil).Once()
+			},
+			expectedCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newTestApplication(t, configModels.Config{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(app)
+			}
+
+			mux := app.Mount()
+			req, _ := http.NewRequest(http.MethodGet, "/v1/events/"+tc.eventID+"/messages", nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+
+			rr := executeRequest(req, mux)
+			checkResponseCode(t, tc.expectedCode, rr)
+		})
+	}
+}

--- a/Backend/cmd/main/stats_test.go
+++ b/Backend/cmd/main/stats_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"Backend/cmd/main/configModels"
+	authMocks "Backend/internal/auth/mocks"
+	storeMocks "Backend/internal/store/mocks"
+	"Backend/internal/store/models"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetStats(t *testing.T) {
+	userID := uuid.New()
+	userIDStr := userID.String()
+
+	tests := []struct {
+		name         string
+		setupMocks   func(*Application)
+		expectedCode int
+	}{
+		{
+			name: "should return admin stats",
+			setupMocks: func(app *Application) {
+				token := &jwt.Token{
+					Claims: jwt.MapClaims{"sub": userIDStr},
+					Valid:  true,
+				}
+				app.Auth.(*authMocks.Authenticator).On("ValidateToken", "valid-token").Return(token, nil).Maybe()
+
+				storeM := app.Store.Users.(*storeMocks.UserStore)
+				storeM.On("RetrieveById", mock.Anything, userID).Return(&models.User{ID: userID, Role: models.Role{Name: "admin", Level: 5}}, nil).Maybe()
+
+				roleM := app.Store.Roles.(*storeMocks.RoleStore)
+				roleM.On("RetrieveByName", mock.Anything, "admin").Return(&models.Role{Name: "admin", Level: 5}, nil).Maybe()
+
+				statsM := app.Store.Stats.(*storeMocks.StatsStore)
+				statsM.On("GetSummary", mock.Anything).Return(&models.AdminStats{
+					TotalRevenue:   50000.0,
+					TotalEvents:    50,
+					RevenueByMonth: map[string]float64{"2026-01": 10000.0},
+					EventsByStatus: map[string]int{"completed": 30},
+				}, nil).Once()
+			},
+			expectedCode: http.StatusOK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			app := newTestApplication(t, configModels.Config{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(app)
+			}
+
+			mux := app.Mount()
+			req, _ := http.NewRequest(http.MethodGet, "/v1/admin/stats", nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+
+			rr := executeRequest(req, mux)
+			checkResponseCode(t, tc.expectedCode, rr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Test list/add/remove favorites (CRUD operations, validation)
- Test get messages by event ID
- Test admin stats endpoint with role middleware

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)